### PR TITLE
Fix broken module entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version" : "0.3.5",
 	"description" : "markdown to roff and html converter",
 	"keywords" : [ "markdown", "roff", "man", "documentation" ],
-	"main" : "ronn",
+	"main" : "lib/ronn",
 	"directories" : {"lib" : "lib"},
 	"engines" : { "node" : ">=0.1.103" },
 	"bin" : { "ronn" : "./bin/ronn.js" },


### PR DESCRIPTION
The current 'main' package.json entry points to a non-existant 'ronn' file in the module's root dir, preventing the module from being require()'d.
