### PR TITLE
Proper handling level-4 headers on roff generating

### DIFF
--- a/lib/ronn.js
+++ b/lib/ronn.js
@@ -95,8 +95,7 @@ exports.Ronn = function(text, version, manual, date) {
 				out = macro(out, "SS", quote(esc(toHTML(node.shift()))));
 			break;
 			case "h4":
-				out = macro(out, "TP");
-				out += esc(toHTML(node.shift()));
+				out = macro(out, "TP", quote(esc(toHTML(node.shift()))));
 			break;
 			case "hr":
 				out = macro(out, "HR");


### PR DESCRIPTION
Before this patch

```
#### Header text

Lorem ipsum dolor sit amet, ...
```

becomes

```
.TP
Header text
.Lorem ipsum dolor sit amet, \.\.\.
```

and now it will be

```
.TP
Header text
.
.P
Lorem ipsum dolor sit amet, \.\.\.
```

as for other headings.
